### PR TITLE
Fix cart empty

### DIFF
--- a/src/main/java/project/market/cart/CartMapper.java
+++ b/src/main/java/project/market/cart/CartMapper.java
@@ -65,4 +65,14 @@ public class CartMapper {
                         .build()
         ).toList();
     }
+
+    public static CartResponse empty (){
+        return CartResponse.builder()
+                .cartId(null)
+                .cartItemResponses(List.of())
+                .totalPrice(0)
+                .totalQuantity(0)
+                .updatedAt(null)
+                .build();
+    }
 }

--- a/src/main/java/project/market/cart/service/CartService.java
+++ b/src/main/java/project/market/cart/service/CartService.java
@@ -28,9 +28,15 @@ public class CartService {
                 () -> new IllegalArgumentException("로그인이 필요합니다")
         );
 
-        Cart cart = cartRepository.findByMemberId(user.getId()).orElseThrow(
-                () -> new IllegalArgumentException("자신의 장바구니만 조회할 수 있습니다")
-        );
+        Cart cart = cartRepository.findByMemberId(user.getId()).orElse(null);
+
+        if(cart == null){
+            return CartMapper.empty();
+        }
+
+        if(!cart.getMember().getId().equals(user.getId())){
+            throw new IllegalArgumentException("자신의 장바구니만 조회 가능합니다");
+        }
 
         List<CartItem> cartItems = cartItemRepository.findAllByCartId(cart.getId());
 

--- a/src/test/java/project/market/CartTest.java
+++ b/src/test/java/project/market/CartTest.java
@@ -28,7 +28,6 @@ import project.market.product.ProductRepository;
 import project.market.product.dto.CreateProductRequest;
 import project.market.product.dto.ProductResponse;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -268,6 +267,29 @@ public class CartTest extends AcceptanceTest{
                 .extract()
                 .as(CartResponse.class);
 
+    }
+
+    @DisplayName("장바구니 null 테스트")
+    @Test
+    public void null테스트(){
+
+        //최초 장바구니 아이템 담기 없이 장바구니 접근 -> 비어있는 장바구니 반환
+        CartResponse cartResponse = RestAssured
+                .given().log().all()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + userToken1)
+                .when()
+                .get("me/carts")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(CartResponse.class);
+
+        assertThat(cartResponse.cartItemResponses()).isEqualTo(List.of());
+        assertThat(cartResponse.cartId()).isNull();
+        assertThat(cartResponse.totalPrice()).isEqualTo(0);
+        assertThat(cartResponse.totalQuantity()).isEqualTo(0);
+        assertThat(cartResponse.updatedAt()).isNull();
     }
 
 


### PR DESCRIPTION
# 장바구니 수정

## 수정 전
- 장바구니는 최초로 CartItem을 담을 때 생성
- 만약 사용자가 최초의 CartItem을 담지 않은 상태에서 장바구니에 접근할 경우
- CartRepisoty.findById().orElseThorow()로 예외 반환

## 수정 후
- 사용자의 장바구니가 생성되어 있지 않은 상태에서 장바구니에 접근해도 예외 반환으로 프로세스를 중단시키지 않고, 비어 있는 장바구니를 Response로 내려줌
- 장바구니가 생성되지 않은 상황이 예외처리 해야할 비정상적 상황이 아니라 정상 작동 되도록 수정
- 장바구니 조회는 되지만 고유 Id와 안의 내용이 없는 장바구니가 조회됨